### PR TITLE
migrated to the new POST based api

### DIFF
--- a/israelrailapi/api.py
+++ b/israelrailapi/api.py
@@ -1,4 +1,5 @@
 import time
+import json
 
 import requests
 
@@ -83,12 +84,22 @@ class IsraelRailApi(object):
 
     def request(self, **kwargs):
         self.arguments = self.prepare_arguments(kwargs)
-        return self.parse(requests.get(self.url, params=self.arguments, headers=self.headers))
+        payload = {
+            "methodName": "searchTrainLuzForDateTime",
+            "fromStation": station_name_to_id(kwargs.get('fromStation')),
+            "toStation": station_name_to_id(kwargs.get('toStation')),
+            "date": kwargs.get('date'),
+            "hour": kwargs.get('hour'),
+            "systemType": "2",
+            "scheduleType": "ByDeparture"
+        }
+
+        return self.parse(requests.post(self.url, json=payload, headers=self.headers))
 
 
 class GetRoutesApi(IsraelRailApi):
     def __init__(self):
-        super().__init__('timetable/searchTrainLuzForDateTime',
+        super().__init__('timetable/searchTrain',
                          {'fromStation': {}, 'toStation': {},
                           'date': {},
                           'hour': {'default': '09:00'},

--- a/israelrailapi/train_station.py
+++ b/israelrailapi/train_station.py
@@ -25,9 +25,11 @@ def translate_station(station_name):
     return lookup_station(station_name)
 
 
-def station_name_to_id(station_id, default_language='Eng'):
-    return STATIONS[str(station_id)][default_language]
-
+def station_name_to_id(lookup_name, default_language='Eng'):
+    for station_id in STATIONS:
+        if any(name == str(lookup_name) for name in STATIONS[station_id]):
+            return station_id
+    return lookup_name
 
 if __name__ == '__main__':
     print(STATION_INDEX)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,22 @@
+import unittest
+import israelrailapi
+
+TEST_API_NAME = 'MyApi'
+TEST_PARAMS = {'required': {},
+               'notRequired': {'required': False},
+               'default': {'default': 5}
+               }
+
+
+class ApiTest(unittest.TestCase):
+
+    def test_usage(self):
+        s = israelrailapi.TrainSchedule()
+
+        from_date = "2023-06-24"
+        from_time = "0900"
+
+        q = s.query("tel aviv hashalom", "hod hasharon sokolov", from_date, from_time)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The israeli rail have deprecated the use of the GET timetable/searchTrainLuzForDateTime API

* Changed to POST
* Changed query params to json body
* Added usage test