### PR TITLE
Add `departure_delay` to `TrainRoutePart`

### DIFF
--- a/israelrailapi/api.py
+++ b/israelrailapi/api.py
@@ -29,6 +29,10 @@ class TrainRoutePart(object):
         self.departure = data['departureTime']
         self.platform = data['originPlatform']
         self.dst_platform = data['destPlatform']
+        self.departure_delay = next(
+            (e['difMin'] for e in data.get('etaDiffTimes', []) if e['stationId'] == self.src),
+            0,
+        )
 
     @staticmethod
     def parse_time(t):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,20 @@ TEST_PARAMS = {'required': {},
                }
 
 
+def _route_part_data(eta_diff_times=...):
+    data = {
+        'orignStation': 3600,
+        'destinationStation': 3700,
+        'arrivalTime': '01/01/2026 10:30:00',
+        'departureTime': '01/01/2026 10:00:00',
+        'originPlatform': 1,
+        'destPlatform': 2,
+    }
+    if eta_diff_times is not ...:
+        data['etaDiffTimes'] = eta_diff_times
+    return data
+
+
 class ApiTest(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -24,6 +38,31 @@ class ApiTest(unittest.TestCase):
 
         with self.assertRaises(KeyError):
             self.rail_test.prepare_arguments({'required': 'Hello', 'notRequired': 'Hello', 'random': 7})
+
+
+class TrainRoutePartTest(unittest.TestCase):
+    def test_departure_delay_matching_station(self):
+        data = _route_part_data(eta_diff_times=[
+            {'stationId': 9999, 'difMin': 2},
+            {'stationId': 3600, 'difMin': 5},
+        ])
+        part = api.TrainRoutePart(data)
+        self.assertEqual(part.departure_delay, 5)
+
+    def test_departure_delay_no_matching_station(self):
+        data = _route_part_data(eta_diff_times=[{'stationId': 9999, 'difMin': 7}])
+        part = api.TrainRoutePart(data)
+        self.assertEqual(part.departure_delay, 0)
+
+    def test_departure_delay_empty_list(self):
+        data = _route_part_data(eta_diff_times=[])
+        part = api.TrainRoutePart(data)
+        self.assertEqual(part.departure_delay, 0)
+
+    def test_departure_delay_missing_key(self):
+        data = _route_part_data()
+        part = api.TrainRoutePart(data)
+        self.assertEqual(part.departure_delay, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added a `departure_delay` attribute to `TrainRoutePart`, which extracts the delay (in minutes) for the origin station from the `etaDiffTimes` data, defaulting to 0 if not found.